### PR TITLE
Updated to use project root env variable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+PROJECT_ROOT = '/workspace/terraform-beginner-bootcamp-2023'

--- a/README.md
+++ b/README.md
@@ -22,3 +22,22 @@ The general format will be **MAJOR.MINOR.PATCH**, eg `1.0.1`
 1. Had to adjust permissions
 1. Adjusted .gitpod.yml to utilize the running script and adjusted to use begin rather than init since init only runs on initial startup
 
+
+
+## ENV Video
+some information that we need to know:
+- `env` is a command that will let you view all enviornment variables
+- `env | grep GITPOD` will give us information on all variables that contain the string GITPOD in them
+- the `|` is a pipe command.  It will pass the output generated from the command on its left to the command on the right
+- to print a specific `env variable `echo $<variable name>`
+- can set using `export $HELLO='world'`
+- can unset using `unset HELLO`
+- we can print an envar using `echo $HELLO`
+
+When you open new terminals in VSCode then it will not know about other terminals var.
+If you want to set then globally then you need to use bash profiles
+We can persist env vars in gitpod secret storage
+
+`gp env HELLO='world'`
+
+Then all future terminals will have $HELLO = 'world'

--- a/bin/install_terraform_cli.sh
+++ b/bin/install_terraform_cli.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+cd /workspace
 sudo apt-get update && sudo apt-get install -y gnupg software-properties-common
 
 wget -O- https://apt.releases.hashicorp.com/gpg | \
@@ -17,3 +18,5 @@ sudo tee /etc/apt/sources.list.d/hashicorp.list
 sudo apt update
 
 sudo apt-get install terraform
+
+cd $PROJECT_ROOT


### PR DESCRIPTION
Updated install_terraform_cli script to use /workspaces as the active working folder
Created an env variable called $PROJECT_ROOT to ensure we can easily browse to that folder
Updated Readme with information on env variables
Set a gitpod global env variable that will be accessible in all terminals 